### PR TITLE
Fix signedness comparison

### DIFF
--- a/src/addressing.cc
+++ b/src/addressing.cc
@@ -259,7 +259,7 @@ ir::Value AddressingResolver::raw_demux(ir::Value val, int64_t from, int64_t to)
 
 ir::Value AddressingResolver::demux(ir::Value val, uint64_t output_len)
 {
-	log_assert(val.size() == (uint64_t)stride);
+	log_assert(val.size() == stride);
 	log_assert(output_len % stride == 0);
 	ir::Value demuxed = raw_demux(val, -std::max<int64_t>(0, base_offset),
 			std::max<int64_t>(0, ((int64_t)output_len / stride) - base_offset));
@@ -269,7 +269,7 @@ ir::Value AddressingResolver::demux(ir::Value val, uint64_t output_len)
 
 ir::Value AddressingResolver::raw_mux(ir::Value val, int64_t from, int64_t to, uint64_t stride)
 {
-	log_assert(stride * (to - from) == (int)val.size());
+	log_assert(stride * (to - from) == val.size());
 	ir::Value negative(ir::Sx, stride), positive(ir::Sx, stride);
 
 	if (from < 0) {
@@ -345,10 +345,10 @@ ir::Value AddressingResolver::shift_down(ir::Value val, uint64_t output_len)
 		ir::Value ret(ir::Sx, output_len);
 		std::vector<bool> written(output_len, false);
 
-		for (int64_t i = 0; i < stride; i++) {
+		for (uint64_t i = 0; i < stride; i++) {
 			ir::Value fin, fout;
 
-			for (int64_t j = i; j < val.width(); j += stride)
+			for (uint64_t j = i; j < val.width(); j += stride)
 				fin.append(val[j]);
 
 			fout = shift_down_bitwise(fin, ((int64_t)output_len - i + stride - 1) / stride);
@@ -366,7 +366,7 @@ ir::Value AddressingResolver::shift_down(ir::Value val, uint64_t output_len)
 }
 
 ir::Value AddressingResolver::embed(
-		ir::Value val, uint64_t output_len, int64_t stride, ir::Trit padding)
+		ir::Value val, uint64_t output_len, uint64_t stride, ir::Trit padding)
 {
 	ast_invariant(expr, raw_signal.is_fully_def());
 	int64_t offset = raw_signal.as_const().as_int(true) + base_offset;

--- a/src/builder.cc
+++ b/src/builder.cc
@@ -115,7 +115,7 @@ ir::Value GraphBuilder::Bwmux(ir::Value a, ir::Value b, ir::Value s)
 	log_assert(a.size() == s.size());
 	if (s.is_fully_const()) {
 		ir::Value result(ir::Sx, a.size());
-		for (int i = 0; i < a.size(); i++) {
+		for (uint64_t i = 0; i < a.size(); i++) {
 			if (s[i] == ir::S0)
 				result[i] = a[i];
 			else if (s[i] == ir::S1)
@@ -133,9 +133,10 @@ ir::Value GraphBuilder::Shift(ir::Value a, ir::Value b, bool b_signed, uint64_t 
 		log_assert(!a.empty());
 		int shift_amount = b.as_int(b_signed);
 		ir::Value ret;
-		int i, j;
+		int i;
+		uint64_t j;
 		for (i = shift_amount, j = 0; j < result_width; i++, j++) {
-			if (i >= a.size() || i < 0)
+			if (i >= (int)a.size() || i < 0)
 				ret.append(ir::S0);
 			else
 				ret.append(a[i]);
@@ -152,9 +153,10 @@ ir::Value GraphBuilder::Shiftx(ir::Value a, ir::Value b, bool b_signed, uint64_t
 		log_assert(!a.empty());
 		int shift_amount = b.as_int(b_signed);
 		ir::Value ret;
-		int i, j;
+		int i;
+		uint64_t j;
 		for (i = shift_amount, j = 0; j < result_width; i++, j++) {
-			if (i >= a.size() || i < 0)
+			if (i >= (int)a.size() || i < 0)
 				ret.append(ir::Sx);
 			else
 				ret.append(a[i]);
@@ -173,7 +175,7 @@ ir::Value GraphBuilder::Neg(ir::Value a, bool signed_)
 ir::Value GraphBuilder::Bmux(ir::Value a, ir::Value s)
 {
 	log_assert(a.size() % (1 << s.size()) == 0);
-	log_assert(a.size() >= 1 << s.size());
+	log_assert(a.size() >= 1ULL << s.size());
 	int stride = a.size() >> s.size();
 	if (s.is_fully_def() && s.width() < 32) {
 		return a.extract(s.as_const().as_int() * stride, stride);
@@ -263,11 +265,11 @@ ir::Value GraphBuilder::Biop(ast::BinaryOperator op, ir::Value a, ir::Value b, b
 		int al = 0, bl = 0;
 		// Add +1 to avoid overflows
 		log_assert(a_signed == b_signed);
-		int width = std::max(a.size(), b.size()) + 1;
+		uint64_t width = std::max(a.size(), b.size()) + 1;
 
 		bool seen_undef_bit = false;
 
-		for (int i = 0; i < width; i++) {
+		for (uint64_t i = 0; i < width; i++) {
 			ir::Net abit = i < a.size() ? ir::Net(a[i]) : (a_signed ? a.msb() : ir::Net(ir::S0));
 			ir::Net bbit = i < b.size() ? ir::Net(b[i]) : (b_signed ? b.msb() : ir::Net(ir::S0));
 
@@ -332,7 +334,7 @@ ir::Value GraphBuilder::Unop(ast::UnaryOperator op, ir::Value a, bool a_signed, 
 	return backend->Unop(op, a, a_signed, y_width);
 }
 
-ir::Value GraphBuilder::CountOnes(ir::Value sig, int result_width)
+ir::Value GraphBuilder::CountOnes(ir::Value sig, uint64_t result_width)
 {
 	ir::Value ret;
 	auto width = sig.size();
@@ -344,7 +346,7 @@ ir::Value GraphBuilder::CountOnes(ir::Value sig, int result_width)
 	} else {
 		// Build tree of adders
 		std::vector<ir::Value> curr_level;
-		for (int i = 0; i < width; i++) {
+		for (uint64_t i = 0; i < width; i++) {
 			ir::Value bit = ir::Net(sig[i]);
 			bit.extend_u0(result_width);
 			curr_level.push_back(bit);
@@ -371,7 +373,7 @@ ir::Value GraphBuilder::CountOnes(ir::Value sig, int result_width)
 	return ret;
 }
 
-ir::Value GraphBuilder::Clog2(ir::Value sig, int result_width)
+ir::Value GraphBuilder::Clog2(ir::Value sig, uint64_t result_width)
 {
 	int width = sig.size();
 

--- a/src/initialization.cc
+++ b/src/initialization.cc
@@ -149,7 +149,7 @@ void finalize_variable_initialization(NetlistContext &netlist)
 			auto signal = netlist.convert_static(variable);
 			ir::Value cl, cr; // lhs/rhs of a new connection
 			ir::Const attr_value(ir::Sx, signal.size());
-			for (int i = 0; i < signal.size(); i++) {
+			for (uint64_t i = 0; i < signal.size(); i++) {
 				VariableBit vbit(variable, i);
 				bool register_driven = netlist.register_driven_variables.count(vbit);
 				bool driven = netlist.driven_variables.count(vbit);

--- a/src/slang_frontend.cc
+++ b/src/slang_frontend.cc
@@ -424,7 +424,7 @@ ir::Net matches_pattern(NetlistContext &netlist, const ValuePattern &pattern, ir
 	ir::Value sig, filtered_pat;
 	sig.reserve(value.width());
 	filtered_pat.reserve(value.width());
-	for (int i = 0; i < pattern.size(); i++) {
+	for (uint64_t i = 0; i < pattern.size(); i++) {
 		if (pattern.bits[i].is_wildcard())
 			continue;
 		sig.append(value[i]);
@@ -762,7 +762,7 @@ ir::Value EvalContext::apply_conversion(const ast::ConversionExpression &conv, i
 	const ast::Type &from = conv.operand().type->getCanonicalType();
 	const ast::Type &to = conv.type->getCanonicalType();
 
-	log_assert(op.size() == (int) from.getBitstreamWidth());
+	log_assert(op.size() == from.getBitstreamWidth());
 
 	if (from.isIntegral() && to.isIntegral()) {
 		bool sign_extend = (conv.conversionKind == ast::ConversionKind::Propagated)
@@ -1417,7 +1417,7 @@ ir::Value EvalContext::operator()(ast::Expression const &expr)
 				ir::Value stream = streaming(stream_expr);
 
 				// pad to fit target size
-				ast_invariant(conv, stream.size() <= (int) expr.type->getBitstreamWidth());
+				ast_invariant(conv, stream.size() <= expr.type->getBitstreamWidth());
 				ret = {stream, ir::Value(ir::S0, expr.type->getBitstreamWidth() - stream.size())};
 			}
 		}

--- a/src/slang_frontend.h
+++ b/src/slang_frontend.h
@@ -582,8 +582,8 @@ struct GraphBuilder {
 	ir::Value Unop(ast::UnaryOperator op, ir::Value a, bool a_signed, uint64_t y_width);
 	ir::Value Biop(ast::BinaryOperator op, ir::Value a, ir::Value b,
 				 bool a_signed, bool b_signed, uint64_t y_width);
-	ir::Value CountOnes(ir::Value sig, int result_width);
-	ir::Value Clog2(ir::Value sig, int result_width);
+	ir::Value CountOnes(ir::Value sig, uint64_t result_width);
+	ir::Value Clog2(ir::Value sig, uint64_t result_width);
 
 	void add_input(std::string_view name, ir::Value signal);
 	void add_output(std::string_view name, ir::Value signal);
@@ -807,11 +807,11 @@ struct ValuePattern
 	ValuePattern(ir::Value v)
 	{
 		bits.reserve(v.size());
-		for (int i = 0; i < v.size(); i++)
+		for (uint64_t i = 0; i < v.size(); i++)
 			bits.push_back(PatternBit(v[i]));
 	}
 
-	int size() const { return (int)bits.size(); }
+	uint64_t size() const { return bits.size(); }
 	bool empty() const { return bits.empty(); }
 
 	bool is_fully_concrete() const
@@ -913,7 +913,7 @@ public:
 	bool is_static();
 
 	slang::ConstantRange range;
-	int64_t stride = 1;
+	uint64_t stride = 1;
 private:
 	void interpret_index(ir::Value signal, int64_t width_down = 1, int64_t width_up = 1);
 
@@ -921,7 +921,7 @@ private:
 	ir::Value shift_down_bitwise(ir::Value val, uint64_t output_len);
 	ir::Value raw_demux(ir::Value val, int64_t from, int64_t to);
 	ir::Value raw_mux(ir::Value val, int64_t from, int64_t to, uint64_t stride);
-	ir::Value embed(ir::Value val, uint64_t output_len, int64_t stride, ir::Trit padding);
+	ir::Value embed(ir::Value val, uint64_t output_len, uint64_t stride, ir::Trit padding);
 
 	// these summed together are the zero-based index of the bottom item
 	// of the selection

--- a/src/yosys_plugin/backend_builder.cc
+++ b/src/yosys_plugin/backend_builder.cc
@@ -103,7 +103,7 @@ ir::Value BackendGraphBuilder::Shiftx(
 ir::Value BackendGraphBuilder::Bmux(ir::Value a, ir::Value s)
 {
 	log_assert(a.size() % (1 << s.size()) == 0);
-	log_assert(a.size() >= 1 << s.size());
+	log_assert(a.size() >= 1ULL << s.size());
 	int stride = a.size() >> s.size();
 	auto [id, y] = add_y_wire(stride);
 	bless_cell(canvas->addBmux(id, a, s, y));
@@ -382,7 +382,7 @@ void BackendGraphBuilder::emit_meminit_cell(
 	int abits = 32; // TODO: error out if abits too low
 	int nwords = data.size() / mem->width;
 	log_assert(data.size() % mem->width == 0);
-	log_assert(mask.size() == mem->width);
+	log_assert(mask.size() == (uint64_t)mem->width);
 	RTLIL::Cell *cell = canvas->addCell(new_id(), ID($meminit_v2));
 	cell->setParam(ID::MEMID, mem->name.str());
 	cell->setParam(ID::PRIORITY, meminit_prio_counter++);
@@ -416,7 +416,7 @@ void BackendGraphBuilder::add_memory_init(
 	// Depending on the offset alignment with respect to word boundaries
 	// we might need to emit up to 3 instances of the `$meminit_v2` cell.
 	if (bit_offset % mem->width != 0) {
-		int offset_in_cell = bit_offset % mem->width;
+		uint64_t offset_in_cell = bit_offset % mem->width;
 		uint64_t length = std::min(mem->width - offset_in_cell, data.size());
 		Const data1, mask1;
 		data1.append(Const(Sx, offset_in_cell));
@@ -439,7 +439,7 @@ void BackendGraphBuilder::add_memory_init(
 
 	if (processed < data.size()) {
 		uint64_t length = data.size() - processed;
-		log_assert(length < mem->width);
+		log_assert(length < uint64_t(mem->width));
 		Const data1, mask1;
 		data1.append(data.extract(0, length));
 		data1.append(Const(Sx, mem->width - length));

--- a/src/yosys_plugin/ir.h
+++ b/src/yosys_plugin/ir.h
@@ -58,7 +58,7 @@ public:
 
 	RTLIL::Const &raw_rtlil() { return raw_; }
 
-	int size() const { return raw_.size(); }
+	uint64_t size() const { return raw_.size(); }
 	bool empty() const { return raw_.empty(); }
 
 	Const extract(int offset, int length) const { return raw_.extract(offset, length); }


### PR DESCRIPTION
by looking where stride gets value it seems that it is always uint64_t, also result_width is on all places uint64_t

Please do recheck, but only `shift_amount` (in builder.cc) must be signed and so must be `i`